### PR TITLE
added axios.js

### DIFF
--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const axiosInstance = axios.create({
+    baseURL: "http://localhost:3000",
+});
+
+export default axiosInstance;


### PR DESCRIPTION
Added a separated `axios.js` under a new created `src/services/`

This change is to solve the problem that the professor gave on part 3 submission.

*You should avoid using hardcoded base URL*

To friendly connect to the current code, an `axiosInstance` function is export as default from the file `axios.js`

All pages using axios can be impacted. Relevant pages may include /Signin, /SignUp, and potentially more in developing 

- Replace `import axios from 'axios'` with `import axiosInstance from '../../services/axios';`,
- Delete the declaration of `axiosInstance`
     ~`const baseURL = "http://localhost:3000";`~
     ~`const axiosInstance = axios.create({ baseURL });`~
- Use `axiosInstance` directly.

Thank you.